### PR TITLE
Make Version implement Hashable.

### DIFF
--- a/Version/Version.swift
+++ b/Version/Version.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 
-public struct Version : Equatable, Comparable {
+public struct Version : Hashable, Comparable {
     public let major: Int
     public let minor: Int?
     public let patch: Int?
@@ -92,6 +92,17 @@ public func <(lhs: Version, rhs: Version) -> Bool {
     return lhs.build < rhs.build
 }
 
+extension Version : Hashable {
+    public var hashValue: Int {
+        let majorHash = major.hashValue
+        let minorHash = minor?.hashValue ?? 0
+        let patchHash = patch?.hashValue ?? 0
+        let prereleaseHash = prerelease?.hashValue ?? 0
+        let buildHash = build?.hashValue ?? 0
+        let prime = 31
+        return reduce([majorHash, minorHash, patchHash, prereleaseHash, buildHash], 0) { $0 &* prime &+ $1 }
+    }
+}
 
 // MARK: String conversion
 

--- a/VersionTests/VersionTests.swift
+++ b/VersionTests/VersionTests.swift
@@ -25,6 +25,15 @@ class VersionTests: XCTestCase {
         XCTAssertNotEqual(version, Version(major: 1, minor: 2, patch: 3, prerelease: "alpha.2", build: "B002"))
     }
     
+    func testHashable() {
+        XCTAssertEqual(version.hashValue,    Version(major: 1, minor: 2, patch: 3, prerelease: "alpha.1", build: "B001").hashValue)
+        XCTAssertNotEqual(version.hashValue, Version(major: 2, minor: 2, patch: 3, prerelease: "alpha.1", build: "B001").hashValue)
+        XCTAssertNotEqual(version.hashValue, Version(major: 1, minor: 3, patch: 3, prerelease: "alpha.1", build: "B001").hashValue)
+        XCTAssertNotEqual(version.hashValue, Version(major: 1, minor: 2, patch: 4, prerelease: "alpha.1", build: "B001").hashValue)
+        XCTAssertNotEqual(version.hashValue, Version(major: 1, minor: 2, patch: 3, prerelease: "alpha.2", build: "B001").hashValue)
+        XCTAssertNotEqual(version.hashValue, Version(major: 1, minor: 2, patch: 3, prerelease: "alpha.2", build: "B002").hashValue)
+    }
+    
     func testStringLiteralConvertible() {
         let otherVersion : Version = "1.2.3-alpha.1+B001"
         XCTAssertEqual(version, otherVersion)


### PR DESCRIPTION
There are quite a few scenarios where one might need a `Dictionary<Version, …>` and I happened to stumble across one of them today.