### PR TITLE
Fix conflicts with semver specifications and several bugs.

### DIFF
--- a/Version.podspec
+++ b/Version.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Version"
-  s.version          = "0.3.0"
+  s.version          = "0.4.0-alpha.1"
   s.summary          = "Version represents and compares semantic versions in Swift."
   s.description      = <<-DESC
                        Version is a Swift Library, which enables to represent and compare semantic version numbers.

--- a/Version.podspec
+++ b/Version.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
+  s.watchos.deployment_target = '2.0'
   s.requires_arc = true
 
   s.source_files = 'Version/*.swift'

--- a/Version.xcodeproj/project.pbxproj
+++ b/Version.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		712D32BD19BD148C0093BAD7 /* Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712D32BC19BD148C0093BAD7 /* Regex.swift */; };
 		71B5631719D5CE28009B2C0D /* Test.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 71B5631619D5CE28009B2C0D /* Test.bundle */; };
 		71B5631919D5D344009B2C0D /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71B5631819D5D344009B2C0D /* Helper.swift */; };
+		A48EFFF81B77A5BD002452BA /* VersionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48EFFF71B77A5BD002452BA /* VersionParser.swift */; };
+		A48EFFFA1B77D949002452BA /* VersionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48EFFF91B77D949002452BA /* VersionParserTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +41,8 @@
 		712D32BC19BD148C0093BAD7 /* Regex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Regex.swift; sourceTree = "<group>"; };
 		71B5631619D5CE28009B2C0D /* Test.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Test.bundle; sourceTree = "<group>"; };
 		71B5631819D5D344009B2C0D /* Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helper.swift; sourceTree = "<group>"; };
+		A48EFFF71B77A5BD002452BA /* VersionParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionParser.swift; sourceTree = "<group>"; };
+		A48EFFF91B77D949002452BA /* VersionParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionParserTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,6 +97,7 @@
 			children = (
 				712D32A619BD06570093BAD7 /* Version.h */,
 				712D32BA19BD06620093BAD7 /* Version.swift */,
+				A48EFFF71B77A5BD002452BA /* VersionParser.swift */,
 				71B5631819D5D344009B2C0D /* Helper.swift */,
 				712D32BC19BD148C0093BAD7 /* Regex.swift */,
 				712D32A419BD06570093BAD7 /* Supporting Files */,
@@ -112,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				712D32B019BD06570093BAD7 /* VersionTests.swift */,
+				A48EFFF91B77D949002452BA /* VersionParserTests.swift */,
 				71B5631619D5CE28009B2C0D /* Test.bundle */,
 				712D32AE19BD06570093BAD7 /* Supporting Files */,
 			);
@@ -236,6 +242,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				712D32BB19BD06620093BAD7 /* Version.swift in Sources */,
+				A48EFFF81B77A5BD002452BA /* VersionParser.swift in Sources */,
 				712D32BD19BD148C0093BAD7 /* Regex.swift in Sources */,
 				71B5631919D5D344009B2C0D /* Helper.swift in Sources */,
 			);
@@ -246,6 +253,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				712D32B119BD06570093BAD7 /* VersionTests.swift in Sources */,
+				A48EFFFA1B77D949002452BA /* VersionParserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Version.xcodeproj/project.pbxproj
+++ b/Version.xcodeproj/project.pbxproj
@@ -182,7 +182,8 @@
 		712D329819BD06560093BAD7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0640;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Marius Rackwitz";
 				TargetAttributes = {
 					712D32A019BD06570093BAD7 = {

--- a/Version.xcodeproj/project.pbxproj
+++ b/Version.xcodeproj/project.pbxproj
@@ -342,7 +342,7 @@
 			baseConfigurationReference = 29EA596C1B5A448E002D767E /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 0.3.0;
+				CURRENT_PROJECT_VERSION = 0.4.0;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -361,7 +361,7 @@
 			baseConfigurationReference = 29EA596C1B5A448E002D767E /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 0.3.0;
+				CURRENT_PROJECT_VERSION = 0.4.0;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/Version.xcodeproj/project.pbxproj
+++ b/Version.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -348,6 +349,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Version/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "de.mariusrackwitz.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -366,6 +368,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Version/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "de.mariusrackwitz.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -380,6 +383,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = VersionTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "de.mariusrackwitz.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -389,6 +393,7 @@
 			baseConfigurationReference = 29EA596D1B5A448E002D767E /* UniversalFramework_Test.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = VersionTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "de.mariusrackwitz.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Version.xcodeproj/xcshareddata/xcschemes/Version.xcscheme
+++ b/Version.xcodeproj/xcshareddata/xcschemes/Version.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,6 +48,8 @@
             ReferencedContainer = "container:Version.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = ""
@@ -57,6 +59,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Version.xcodeproj/xcshareddata/xcschemes/VersionTests.xcscheme
+++ b/Version.xcodeproj/xcshareddata/xcschemes/VersionTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,6 +48,8 @@
             ReferencedContainer = "container:Version.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -57,6 +59,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Version/Helper.swift
+++ b/Version/Helper.swift
@@ -8,13 +8,9 @@
 
 import Foundation
 
-
+// based on: http://stackoverflow.com/a/30593673/4194189
 extension Array {
-    func try(index: Int) -> T? {
-        if index >= 0 && index < count {
-            return self[index]
-        } else {
-            return nil
-        }
+    subscript (safe index: Int) -> Element? {
+        return indices ~= index ? self[index] : nil
     }
 }

--- a/Version/Info.plist
+++ b/Version/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>de.mariusrackwitz.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Version/Regex.swift
+++ b/Version/Regex.swift
@@ -11,7 +11,7 @@ import Foundation
 
 extension String {
     var range: NSRange {
-        return NSMakeRange(0, count(self.utf16))
+        return NSMakeRange(0, self.utf16.count)
     }
     
     func substringWithRange(range: NSRange) -> String {
@@ -26,39 +26,29 @@ struct Regex {
     let options: NSRegularExpressionOptions
     let matcher: NSRegularExpression!
     
-    init?(pattern: String, options: NSRegularExpressionOptions = nil) {
-        var error: NSError?
-        self.init(pattern: pattern, options: options, error: &error)
-        if self.matcher == nil {
-            return nil
-        }
-    }
-    
-    init(pattern: String, options: NSRegularExpressionOptions = nil, var error: NSErrorPointer? = nil) {
+    init(pattern: String, options: NSRegularExpressionOptions = []) throws {
         self.pattern = pattern
         self.options = options
-        var e: NSError?
-        self.matcher = NSRegularExpression(pattern: self.pattern, options: self.options, error: &e)
-        if let pointer = error {
-            pointer.memory = e
-        }
+        self.matcher = try NSRegularExpression(pattern: self.pattern, options: self.options)
     }
     
-    func match(string: String, options: NSMatchingOptions = nil) -> Bool {
+    func match(string: String, options: NSMatchingOptions = []) -> Bool {
         return self.matcher.numberOfMatchesInString(string, options: options, range: string.range) != 0
     }
     
-    func matchingsOf(string: String, options: NSMatchingOptions = nil) -> [String] {
+    func matchingsOf(string: String, options: NSMatchingOptions = []) -> [String] {
         var matches : [String] = []
         self.matcher.enumerateMatchesInString(string, options: options, range: string.range) {
-            (result: NSTextCheckingResult!, flags: NSMatchingFlags, stop: UnsafeMutablePointer<ObjCBool>) in
-            matches.append(string.substringWithRange(result.range))
+            (result: NSTextCheckingResult?, flags: NSMatchingFlags, stop: UnsafeMutablePointer<ObjCBool>) in
+            if let result = result {
+                matches.append(string.substringWithRange(result.range))
+            }
         }
         return matches
     }
     
-    func groupsOfFirstMatch(string: String, options: NSMatchingOptions = nil) -> [String] {
-        var match = self.matcher.firstMatchInString(string, options: options, range: string.range)
+    func groupsOfFirstMatch(string: String, options: NSMatchingOptions = []) -> [String] {
+        let match = self.matcher.firstMatchInString(string, options: options, range: string.range)
         var groups : [String] = []
         if let match = match {
             for i in 0..<match.numberOfRanges {
@@ -90,6 +80,6 @@ extension Regex: StringLiteralConvertible {
     }
     
     init(stringLiteral value: StringLiteralType) {
-        self.init(pattern: value, error: nil)
+        try! self.init(pattern: value)
     }
 }

--- a/Version/Regex.swift
+++ b/Version/Regex.swift
@@ -15,51 +15,66 @@ extension String {
     }
     
     func substringWithRange(range: NSRange) -> String {
-        let rangeStart : String.Index = advance(self.startIndex, range.location)
-        return self.substringWithRange(rangeStart..<advance(rangeStart, range.length))
+        let rangeStart : String.Index = self.startIndex.advancedBy(range.location)
+		let rangeEnd = rangeStart.advancedBy(range.length)
+        return self.substringWithRange(rangeStart..<rangeEnd)
     }
 }
 
 
+extension NSTextCheckingResult {
+	func groupsInString(string: String) -> [String?] {
+		return (0..<self.numberOfRanges).map {
+			let range = self.rangeAtIndex($0)
+			return (range.location != NSNotFound) ? string.substringWithRange(range) : nil
+		}
+	}
+}
+
 struct Regex {
-    let pattern: String
-    let options: NSRegularExpressionOptions
-    let matcher: NSRegularExpression!
-    
-    init(pattern: String, options: NSRegularExpressionOptions = []) throws {
-        self.pattern = pattern
-        self.options = options
-        self.matcher = try NSRegularExpression(pattern: self.pattern, options: self.options)
-    }
-    
-    func match(string: String, options: NSMatchingOptions = []) -> Bool {
-        return self.matcher.numberOfMatchesInString(string, options: options, range: string.range) != 0
-    }
-    
-    func matchingsOf(string: String, options: NSMatchingOptions = []) -> [String] {
-        var matches : [String] = []
-        self.matcher.enumerateMatchesInString(string, options: options, range: string.range) {
-            (result: NSTextCheckingResult?, flags: NSMatchingFlags, stop: UnsafeMutablePointer<ObjCBool>) in
-            if let result = result {
-                matches.append(string.substringWithRange(result.range))
-            }
-        }
-        return matches
-    }
-    
-    func groupsOfFirstMatch(string: String, options: NSMatchingOptions = []) -> [String] {
-        let match = self.matcher.firstMatchInString(string, options: options, range: string.range)
-        var groups : [String] = []
-        if let match = match {
-            for i in 0..<match.numberOfRanges {
-                let range = match.rangeAtIndex(i)
-                if range.location != NSNotFound {
-                    groups.append(string.substringWithRange(range))
-                }
-            }
-        }
-        return groups
-    }
+	let pattern: String
+	let options: NSRegularExpressionOptions
+	let matcher: NSRegularExpression!
+	
+	init(pattern: String, options: NSRegularExpressionOptions = []) throws {
+		self.pattern = pattern
+		self.options = options
+		self.matcher = try NSRegularExpression(pattern: self.pattern, options: self.options)
+	}
+	
+	func match(string: String, options: NSMatchingOptions = []) -> Bool {
+		return self.matcher.numberOfMatchesInString(string, options: options, range: string.range) != 0
+	}
+	
+	func matchingsOf(string: String, options: NSMatchingOptions = []) -> [String] {
+		var matches : [String] = []
+		self.matcher.enumerateMatchesInString(string, options: options, range: string.range) {
+			(result: NSTextCheckingResult?, flags: NSMatchingFlags, stop: UnsafeMutablePointer<ObjCBool>) in
+			if let result = result {
+				matches.append(string.substringWithRange(result.range))
+			}
+		}
+		return matches
+	}
+	
+	func matchingGroupsOf(string: String, options: NSMatchingOptions = []) -> [[String?]] {
+		var matches : [[String?]] = []
+		self.matcher.enumerateMatchesInString(string, options: options, range: string.range) {
+			(result: NSTextCheckingResult?, flags: NSMatchingFlags, stop: UnsafeMutablePointer<ObjCBool>) in
+			if let result = result {
+				matches.append(result.groupsInString(string))
+			}
+		}
+		return matches
+	}
+	
+	func groupsOfFirstMatch(string: String, options: NSMatchingOptions = []) -> [String?] {
+		if let match = self.matcher.firstMatchInString(string, options: options, range: string.range) {
+			return match.groupsInString(string)
+		} else {
+			return []
+		}
+	}
 }
 
 func ==(lhs: Regex, rhs: Regex) -> Bool {

--- a/Version/Version.swift
+++ b/Version/Version.swift
@@ -72,17 +72,13 @@ public struct Version {
     ///
     public static func parse(value: String) -> Version? {
         let parts = pattern.groupsOfFirstMatch(value)
-        
-        if let major = parts.try(1)?.toInt() {
-            return Version(
-                major: major,
-                minor: parts.try(2)?.toInt(),
-                patch: parts.try(3)?.toInt(),
-                prerelease: parts.try(4),
-                build: parts.try(5)
-            )
-        } else {
-            return nil
+        return parts[safe: 1].flatMap { Int($0) }.flatMap { (major: Int) in
+            var version = Version(major: major)
+            version.minor      = parts[safe: 2].flatMap { Int($0) }
+            version.patch      = parts[safe: 3].flatMap { Int($0) }
+            version.prerelease = parts[safe: 4]
+            version.build      = parts[safe: 5]
+            return version
         }
     }
     
@@ -131,7 +127,7 @@ public func <(lhs: Version, rhs: Version) -> Bool {
             for (l, r) in comparables {
                 if l != r {
                     if numberPattern.match(l) && numberPattern.match(r) {
-                        return l.toInt() < r.toInt()
+                        return Int(l) < Int(r)
                     } else {
                         return l < r
                     }
@@ -156,14 +152,14 @@ extension Version : Hashable {
         let prereleaseHash = prerelease?.hashValue ?? 0
         let buildHash = build?.hashValue ?? 0
         let prime = 31
-        return reduce([majorHash, minorHash, patchHash, prereleaseHash, buildHash], 0) { $0 &* prime &+ $1 }
+        return [majorHash, minorHash, patchHash, prereleaseHash, buildHash].reduce(0) { $0 &* prime &+ $1 }
     }
 }
 
 
 // MARK: String Conversion
 
-extension Version : Printable {
+extension Version : CustomStringConvertible {
     public var description: String {
         return "".join([
             "\(major)",
@@ -176,9 +172,9 @@ extension Version : Printable {
 }
 
 
-let pattern = Regex(pattern: "([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(?:-([0-9A-Za-z-.]+))?(?:\\+([0-9A-Za-z-]+))?")!
-let numberPattern = Regex(pattern: "[0-9]+")!
-let anchoredPattern = Regex(pattern: "/\\A\\s*(\(pattern.pattern))?\\s*\\z/")!
+let pattern : Regex = "([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(?:-([0-9A-Za-z-.]+))?(?:\\+([0-9A-Za-z-]+))?"
+let numberPattern : Regex = "[0-9]+"
+let anchoredPattern = try! Regex(pattern: "/\\A\\s*(\(pattern.pattern))?\\s*\\z/")
 
 extension Version {
     public static func valid(string: String) -> Bool {
@@ -220,7 +216,7 @@ extension NSBundle {
     
     func versionFromInfoDicitionary(forKey key: String) -> Version? {
         if let bundleVersion = self.infoDictionary?[key] as? NSString {
-            return Version(String(bundleVersion))
+            return Version.parse(String(bundleVersion))
         }
         return nil
     }
@@ -228,7 +224,7 @@ extension NSBundle {
 
 extension NSProcessInfo {
     /// The version of the operating system on which the process is executing.
-    @availability(iOS, introduced=8.0)
+    @available(iOS, introduced=8.0)
     public var operationSystemVersion: Version {
         let version : NSOperatingSystemVersion = self.operatingSystemVersion
         return Version(

--- a/Version/VersionParser.swift
+++ b/Version/VersionParser.swift
@@ -1,0 +1,99 @@
+//
+//  VersionParser.swift
+//  Version
+//
+//  Created by Vincent Esche on 8/9/15.
+//  Copyright © 2015 Vincent Esche. All rights reserved.
+//
+
+import Foundation
+
+enum VersionParserError: ErrorType {
+	case MissingMinorComponent
+	case MissingPatchComponent
+	case InvalidComponents
+	case InvalidMajorComponent
+	case InvalidMinorComponent
+	case InvalidPatchComponent
+}
+
+public struct VersionParser {
+	
+	static func versionPattern(strict strict: Bool, anchored: Bool) -> Regex {
+		let pattern: String
+		if strict {
+			pattern = "(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-.]+))?(?:\\+([0-9A-Za-z-]+))?"
+		} else {
+			pattern = "([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(?:-([0-9A-Za-z-.]+))?(?:\\+([0-9A-Za-z-]+))?"
+		}
+		return try! Regex(pattern: (anchored) ? "\\A\(pattern)?\\z" : pattern)
+	}
+	
+	static func numberPattern(strict strict: Bool, anchored: Bool) -> Regex {
+		let pattern: String
+		if strict {
+			pattern = "0|[1-9][0-9]*"
+		} else {
+			pattern = "[0-9]+"
+		}
+		return try! Regex(pattern: (anchored) ? "\\A\(pattern)?\\z" : pattern)
+	}
+	
+	let strict: Bool
+	let versionRegex: Regex
+	let numberRegex: Regex
+	
+	public init(strict: Bool = true) {
+		self.strict = strict
+		self.versionRegex = VersionParser.versionPattern(strict: self.strict, anchored: true)
+		self.numberRegex = VersionParser.numberPattern(strict: self.strict, anchored: true)
+	}
+	
+	public func parse(string: String) throws -> Version {
+		let components = self.versionRegex.groupsOfFirstMatch(string)
+		return try self.parse(components)
+	}
+	
+	public func parse(components: [String?]) throws -> Version {
+		var version = Version()
+		
+		if components.count != 6 { // all, major, minor, patch, prerelease, build
+			throw VersionParserError.InvalidComponents
+		}
+		
+		if self.strict {
+			if components[2] == nil {
+				throw VersionParserError.MissingMinorComponent
+			} else if components[3] == nil {
+				throw VersionParserError.MissingPatchComponent
+			}
+		}
+		
+		let majorComponent = components[1]
+		let minorComponent = components[2]
+		let patchComponent = components[3]
+		
+		if let major = majorComponent.flatMap({ Int($0) }) {
+			version.major = major
+		} else {
+			throw VersionParserError.InvalidMajorComponent
+		}
+		
+		if let minor = minorComponent.flatMap({ Int($0) }) {
+			version.minor = minor
+		} else if minorComponent != nil {
+			throw VersionParserError.InvalidMinorComponent
+		}
+		
+		if let patch = patchComponent.flatMap({ Int($0) }) {
+			version.patch = patch
+		} else if patchComponent != nil {
+			throw VersionParserError.InvalidPatchComponent
+		}
+		
+		version.prerelease = components[4]
+		version.build = components[5]
+		
+		return version
+	}
+}

--- a/VersionTests/Info.plist
+++ b/VersionTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>de.mariusrackwitz.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/VersionTests/VersionParserTests.swift
+++ b/VersionTests/VersionParserTests.swift
@@ -1,0 +1,197 @@
+//
+//  VersionParserTests.swift
+//  Version
+//
+//  Created by Vincent Esche on 8/9/15.
+//  Copyright © 2015 Vincent Esche. All rights reserved.
+//
+
+import XCTest
+
+import Version
+
+/*
+#!/usr/bin/ruby
+
+# Ruby script used for generating carthesian product of version components:
+
+major = ['1']
+minor = ['.2', '.0']
+patch = ['.3', '.0']
+prerelease = ['-alpha', '']
+build = ['+deadbeef', '']
+product = major.product(minor, patch, prerelease, build)
+versions = product.map(&:join)
+puts versions.sort
+*/
+
+class VersionParserTests: XCTestCase {
+	var validStrings: [String] {
+		return [
+			"1.0.0-alpha",
+			"1.0.0-alpha+deadbeef",
+			"1.0.0",
+			"1.0.0+deadbeef",
+			"1.0.3-alpha",
+			"1.0.3-alpha+deadbeef",
+			"1.0.3",
+			"1.0.3+deadbeef",
+			"1.2.0-alpha",
+			"1.2.0-alpha+deadbeef",
+			"1.2.0+deadbeef",
+			"1.2.0",
+			"1.2.3-alpha",
+			"1.2.3-alpha+deadbeef",
+			"1.2.3",
+			"1.2.3+deadbeef",
+		]
+	}
+	
+	var semiValidStrings: [String] {
+		return [
+			"1-alpha",
+			"1.0-alpha",
+			"1-alpha+deadbeef",
+			"1.0-alpha+deadbeef",
+			"1",
+			"1.0",
+			"1+deadbeef",
+			"1.0+deadbeef",
+			"1.2-alpha",
+			"1.2-alpha+deadbeef",
+			"1.2+deadbeef",
+			"1.2",
+			"01.2.3",
+			"1.02.3",
+			"1.2.03",
+		]
+	}
+	
+	var invalidStrings: [String] {
+		return [
+			"",
+			"lorem ipsum",
+			"a.0.0-alpha+deadbeef",
+			"0.b.0-alpha+deadbeef",
+			"0.0.c-alpha+deadbeef",
+			"0.0.0- +deadbeef",
+			"0.0.0-+deadbeef",
+			"0.0.0-+",
+			"0.0.0-_+deadbeef",
+			"0.0.0-alpha+_"
+		]
+	}
+	
+	var validVersions: [Version] {
+		return [
+			Version(major: 1, minor: 0, patch:0, prerelease: "alpha"),
+			Version(major: 1, minor: 0, patch:0, prerelease: "alpha", build: "deadbeef"),
+			Version(major: 1, minor: 0, patch:0),
+			Version(major: 1, minor: 0, patch:0, prerelease: nil, build: "deadbeef"),
+			Version(major: 1, minor: 0, patch:3, prerelease: "alpha"),
+			Version(major: 1, minor: 0, patch:3, prerelease: "alpha", build: "deadbeef"),
+			Version(major: 1, minor: 0, patch:3),
+			Version(major: 1, minor: 0, patch:3, prerelease: nil, build: "deadbeef"),
+			Version(major: 1, minor: 2, patch:0, prerelease: "alpha"),
+			Version(major: 1, minor: 2, patch:0, prerelease: "alpha", build: "deadbeef"),
+			Version(major: 1, minor: 2, patch:0, prerelease: nil, build: "deadbeef"),
+			Version(major: 1, minor: 2, patch:0),
+			Version(major: 1, minor: 2, patch:3, prerelease: "alpha"),
+			Version(major: 1, minor: 2, patch:3, prerelease: "alpha", build: "deadbeef"),
+			Version(major: 1, minor: 2, patch:3),
+			Version(major: 1, minor: 2, patch:3, prerelease: nil, build: "deadbeef"),
+		]
+	}
+	
+	var semiValidVersions: [Version] {
+		return [
+			Version(major: 1, minor: nil, patch: nil, prerelease: "alpha"),
+			Version(major: 1, minor: 0, patch: nil, prerelease: "alpha"),
+			Version(major: 1, minor: nil, patch: nil, prerelease: "alpha", build: "deadbeef"),
+			Version(major: 1, minor: 0, patch: nil, prerelease: "alpha", build: "deadbeef"),
+			Version(major: 1),
+			Version(major: 1, minor: 0),
+			Version(major: 1, minor: nil, patch: nil, prerelease: nil, build: "deadbeef"),
+			Version(major: 1, minor: 0, patch: nil, prerelease: nil, build: "deadbeef"),
+			Version(major: 1, minor: 2, patch: nil, prerelease: "alpha"),
+			Version(major: 1, minor: 2, patch: nil, prerelease: "alpha", build: "deadbeef"),
+			Version(major: 1, minor: 2, patch: nil, prerelease: nil, build: "deadbeef"),
+			Version(major: 1, minor: 2),
+			Version(major: 1, minor: 2, patch: 3),
+			Version(major: 1, minor: 2, patch: 3),
+			Version(major: 1, minor: 2, patch: 3),
+		]
+	}
+	
+    func testStrictParsingOfValidStrings() {
+		let parser = VersionParser(strict: true)
+		for (string, version) in zip(self.validStrings, self.validVersions) {
+			do {
+				let parsedVersion = try parser.parse(string)
+				XCTAssert(parsedVersion === version)
+			} catch let error {
+				XCTFail("\(error)")
+			}
+		}
+    }
+
+	func testStrictParsingOfSemiValidStrings() {
+		let parser = VersionParser(strict: true)
+		for string in self.semiValidStrings {
+			do {
+				try parser.parse(string)
+				XCTFail()
+			} catch {
+				
+			}
+		}
+	}
+	
+	func testStrictParsingOfInvalidStrings() {
+		let parser = VersionParser(strict: true)
+		for string in self.invalidStrings {
+			do {
+				try parser.parse(string)
+				XCTFail()
+			} catch {
+				
+			}
+		}
+	}
+	
+	func testLenientParsingOfValidStrings() {
+		let parser = VersionParser(strict: false)
+		for (string, version) in zip(self.validStrings, self.validVersions) {
+			do {
+				let parsedVersion = try parser.parse(string)
+				XCTAssert(parsedVersion === version)
+			} catch let error {
+				XCTFail("\(error)")
+			}
+		}
+	}
+	
+	func testLenientParsingOfSemiValidStrings() {
+		let parser = VersionParser(strict: false)
+		for (string, version) in zip(self.semiValidStrings, self.semiValidVersions) {
+			do {
+				let parsedVersion = try parser.parse(string)
+				XCTAssert(parsedVersion === version)
+			} catch let error {
+				XCTFail("\(error)")
+			}
+		}
+	}
+	
+	func testLenientParsingOfInvalidStrings() {
+		let parser = VersionParser(strict: false)
+		for string in self.invalidStrings {
+			do {
+				try parser.parse(string)
+				XCTFail()
+			} catch {
+				
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes problems described in issue #10.

:zap: CAUTION: This is a breaking change! :bomb:

What I changed/fixed:

1. In order to allow Version to leniently parse invalid (according to semver, at least), yet common versions (and print them back identically to how they were parsed) I added `Version.canonicalMinor` and `Version.canonicalPatch` for internal handling.

```swift
public var canonicalMinor: Int {
	return self.minor ?? 0
}
```

2. I extracted the parsing code into a dedicated `VersionParser` class, which can now be initialized with a `strict` flag (`false` being the default). Again, we don't want to break parsing of semi-valid version strings.

3. This is a big one. In order to be a valid semantic version it should ignore `build` in comparisons.
Ignoring `build` would however lead to unexpected results when comparing “1.0.0+A” and “1.0.0+B”. One would expect these to not be equal.
Then again as long as one cannot guarantee a comparable build number (it might be a partial git commit hash, for which sorting makes no sense whatsoever)
I therefor removed comparison of build from “func<“, "func==“ and “hashValue” and implemented `func===` to re-enable equality checks with build:

```swift
public func ===(lhs: Version, rhs: Version) -> Bool {
	return (lhs == rhs) && (lhs.build == rhs.build)
}
```

4. Fixed.

5. A nil-value in minor or patch now is considered equal to “0”.