### PR TITLE
fix build issue on OSX to support lower deployment target(10.9)

### DIFF
--- a/Version.xcodeproj/project.pbxproj
+++ b/Version.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Version/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.mariusrackwitz.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -376,6 +377,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Version/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.mariusrackwitz.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Version/Version.swift
+++ b/Version/Version.swift
@@ -248,6 +248,7 @@ extension NSBundle {
 
 extension NSProcessInfo {
     /// The version of the operating system on which the process is executing.
+    @available(OSX, introduced=10.10)
     @available(iOS, introduced=8.0)
     public var operationSystemVersion: Version {
         let version : NSOperatingSystemVersion = self.operatingSystemVersion


### PR DESCRIPTION
I happen to have a project using Version that has a deployment target of OSX 10.9. And when using Carthage to build the dependencies, got something like this

```
Module file's minimum deployment target is OS X v10.11:
```

Therefore I made some adjustments to support building for 10.9