### PR TITLE
Fix compilation issue on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ before_install:
 
 script:
   - swift package generate-xcodeproj
-  - xcodebuild test -scheme Version-Package -destination platform="iOS Simulator,name=iPhone 11 Pro Max,OS=13.2" | xcpretty -c && exit ${PIPESTATUS[0]}
+  - xcodebuild test -scheme Version-Package -destination platform="iOS Simulator,name=iPhone 11 Pro Max,OS=13.2.2" | xcpretty -c && exit ${PIPESTATUS[0]}
   - xcodebuild test -project Version.xcodeproj -scheme Version-Package -sdk macosx | xcpretty -c && exit ${PIPESTATUS[0]}
   - pod lib lint Version.podspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ osx_image: xcode11.2
 language: swift
 
 before_install:
- - sudo gem install -N cocoapods --pre
- - sudo gem install -N xcpretty
- - sudo gem install -N xcpretty-travis-formatter
+  - sudo gem install -N cocoapods --pre
+  - sudo gem install -N xcpretty
+  - sudo gem install -N xcpretty-travis-formatter
 
 script:
- - swift package generate-xcodeproj
- - xcodebuild test -scheme Version-Package -destination platform="iOS Simulator,name=iPhone 11 Pro Max,OS=13.2" | xcpretty -c && exit ${PIPESTATUS[0]}
- - xcodebuild test -project Version.xcodeproj -scheme Version-Package -sdk macosx | xcpretty -c && exit ${PIPESTATUS[0]}
- - pod lib lint Version.podspec
+  - swift package generate-xcodeproj
+  - xcodebuild test -scheme Version-Package -destination platform="iOS Simulator,name=iPhone 11 Pro Max,OS=13.2" | xcpretty -c && exit ${PIPESTATUS[0]}
+  - xcodebuild test -project Version.xcodeproj -scheme Version-Package -sdk macosx | xcpretty -c && exit ${PIPESTATUS[0]}
+  - pod lib lint Version.podspec

--- a/Sources/Version/Version.swift
+++ b/Sources/Version/Version.swift
@@ -255,7 +255,11 @@ extension Version: Codable {}
 extension Bundle {
     /// The marketing version number of the bundle.
     public var version : Version? {
+       #if os(Linux)
+        return nil
+       #else
         return self.versionFromInfoDicitionary(forKey: String(kCFBundleVersionKey))
+       #endif
     }
     
     /// The short version number of the bundle.


### PR DESCRIPTION
Fix this issue on Linux stack.

```
remote: /tmp/build_90a63a7a429caba3f86535bd8a819ae1/.build/checkouts/Version/Sources/Version/Version.swift:258:63: error: use of unresolved identifier 'kCFBundleVersionKey'
remote:         return self.versionFromInfoDicitionary(forKey: String(kCFBundleVersionKey))
```